### PR TITLE
chore(build): update analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ max_line_length = 9999
 indent_size = 2
 
 # XML indentation
-[*.{csproj,xml}]
+[*.{csproj,xml,ruleset}]
 indent_size = 2
 
 ###############################

--- a/Jellyfin.Plugin.Tmdb/Jellyfin.Plugin.Tmdb.csproj
+++ b/Jellyfin.Plugin.Tmdb/Jellyfin.Plugin.Tmdb.csproj
@@ -1,38 +1,36 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.0.0.0</FileVersion>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <None Remove="Configuration\config.html" />
-        <EmbeddedResource Include="Configuration\config.html" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Remove="Configuration\config.html" />
+    <EmbeddedResource Include="Configuration\config.html" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Jellyfin.Data" Version="10.*-*" />
-        <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-        <PackageReference Include="Jellyfin.Common" Version="10.*-*" />
-        <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-        <PackageReference Include="TMDbLib" Version="1.8.1" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Jellyfin.Data" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Common" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="TMDbLib" Version="1.8.1" />
+  </ItemGroup>
 
-    <!-- Code Analyzers-->
-    <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="All" />
-        <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-        <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
-    </ItemGroup>
-
-    <PropertyGroup>
-        <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    </PropertyGroup>
+  <!-- Code Analyzers-->
+  <ItemGroup>
+    <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
+  </ItemGroup>
 
 </Project>

--- a/Jellyfin.Plugin.Tmdb/Providers/BoxSets/TmdbBoxSetProvider.cs
+++ b/Jellyfin.Plugin.Tmdb/Providers/BoxSets/TmdbBoxSetProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
@@ -85,14 +86,14 @@ namespace Jellyfin.Plugin.Tmdb.Providers.BoxSets
         }
 
         /// <inheritdoc />
-        public async Task<MetadataResult<BoxSet>> GetMetadata(BoxSetInfo id, CancellationToken cancellationToken)
+        public async Task<MetadataResult<BoxSet>> GetMetadata(BoxSetInfo info, CancellationToken cancellationToken)
         {
-            var tmdbId = Convert.ToInt32(id.GetProviderId(MetadataProvider.Tmdb), CultureInfo.InvariantCulture);
-            var language = id.MetadataLanguage;
+            var tmdbId = Convert.ToInt32(info.GetProviderId(MetadataProvider.Tmdb), CultureInfo.InvariantCulture);
+            var language = info.MetadataLanguage;
             // We don't already have an Id, need to fetch it
             if (tmdbId <= 0)
             {
-                var searchResults = await _tmdbClientManager.SearchCollectionAsync(id.Name, language, cancellationToken).ConfigureAwait(false);
+                var searchResults = await _tmdbClientManager.SearchCollectionAsync(info.Name, language, cancellationToken).ConfigureAwait(false);
 
                 if (searchResults != null && searchResults.Count > 0)
                 {

--- a/Jellyfin.Plugin.Tmdb/Providers/People/TmdbPersonProvider.cs
+++ b/Jellyfin.Plugin.Tmdb/Providers/People/TmdbPersonProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
@@ -93,14 +94,14 @@ namespace Jellyfin.Plugin.Tmdb.Providers.People
         }
 
         /// <inheritdoc />
-        public async Task<MetadataResult<Person>?> GetMetadata(PersonLookupInfo id, CancellationToken cancellationToken)
+        public async Task<MetadataResult<Person>?> GetMetadata(PersonLookupInfo info, CancellationToken cancellationToken)
         {
-            var personTmdbId = Convert.ToInt32(id.GetProviderId(MetadataProvider.Tmdb), CultureInfo.InvariantCulture);
+            var personTmdbId = Convert.ToInt32(info.GetProviderId(MetadataProvider.Tmdb), CultureInfo.InvariantCulture);
 
             // We don't already have an Id, need to fetch it
             if (personTmdbId <= 0)
             {
-                var personSearchResults = await _tmdbClientManager.SearchPersonAsync(id.Name, cancellationToken).ConfigureAwait(false);
+                var personSearchResults = await _tmdbClientManager.SearchPersonAsync(info.Name, cancellationToken).ConfigureAwait(false);
                 if (personSearchResults.Count > 0)
                 {
                     personTmdbId = personSearchResults[0].Id;
@@ -123,7 +124,7 @@ namespace Jellyfin.Plugin.Tmdb.Providers.People
                 {
                     // Take name from incoming info, don't rename the person
                     // TODO: This should go in PersonMetadataService, not each person provider
-                    Name = id.Name,
+                    Name = info.Name,
                     HomePageUrl = person.Homepage,
                     Overview = person.Biography,
                     PremiereDate = person.Birthday?.ToUniversalTime(),

--- a/Jellyfin.Plugin.Tmdb/TmdbUtils.cs
+++ b/Jellyfin.Plugin.Tmdb/TmdbUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using MediaBrowser.Model.Entities;
 using TMDbLib.Objects.General;
 
@@ -45,6 +46,7 @@ namespace Jellyfin.Plugin.Tmdb
         /// </summary>
         /// <param name="crew">Crew member to map against the Jellyfin person types.</param>
         /// <returns>The Jellyfin person type.</returns>
+        [SuppressMessage("Microsoft.Maintainability", "CA1309: Use ordinal StringComparison", Justification = "AFAIK we WANT InvariantCulture comparisons here and not Ordinal")]
         public static string MapCrewToPersonType(Crew crew)
         {
             if (crew.Department.Equals("production", StringComparison.InvariantCultureIgnoreCase)

--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -10,6 +10,8 @@
 
     <!-- disable warning SA1009: Closing parenthesis should be followed by a space. -->
     <Rule Id="SA1009" Action="None" />
+    <!-- disable warning SA1011: Closing square bracket should be followed by a space. -->
+    <Rule Id="SA1011" Action="None" />
     <!-- disable warning SA1101: Prefix local calls with 'this.' -->
     <Rule Id="SA1101" Action="None" />
     <!-- disable warning SA1108: Block statements should not contain embedded comments -->
@@ -30,11 +32,17 @@
     <Rule Id="SA1515" Action="None" />
     <!-- disable warning SA1600: Elements should be documented -->
     <Rule Id="SA1600" Action="None" />
+    <!-- disable warning SA1602: Enumeration items should be documented -->
+    <Rule Id="SA1602" Action="None" />
     <!-- disable warning SA1633: The file header is missing or not located at the top of the file -->
     <Rule Id="SA1633" Action="None" />
   </Rules>
 
-  <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.Design">
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.Design">
+    <!-- error on CA2016: Forward the CancellationToken parameter to methods that take one
+        or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token -->
+    <Rule Id="CA2016" Action="Error" />
+
     <!-- disable warning CA1031: Do not catch general exception types -->
     <Rule Id="CA1031" Action="Info" />
     <!-- disable warning CA1032: Implement standard exception constructors -->
@@ -45,6 +53,8 @@
     <Rule Id="CA1716" Action="Info" />
     <!-- disable warning CA1720: Identifiers should not contain type names -->
     <Rule Id="CA1720" Action="Info" />
+    <!-- disable warning CA1805: Do not initialize unnecessarily -->
+    <Rule Id="CA1805" Action="Info" />
     <!-- disable warning CA1812: internal class that is apparently never instantiated.
         If so, remove the code from the assembly.
         If this class is intended to contain only static members, make it static -->
@@ -53,7 +63,11 @@
     <Rule Id="CA1822" Action="Info" />
     <!-- disable warning CA2000: Dispose objects before losing scope -->
     <Rule Id="CA2000" Action="Info" />
+    <!-- disable warning CA5394: Do not use insecure randomness -->
+    <Rule Id="CA5394" Action="Info" />
 
+    <!-- disable warning CA1014: Mark assemblies with CLSCompliantAttribute -->
+    <Rule Id="CA1014" Action="Info" />
     <!-- disable warning CA1054: Change the type of parameter url from string to System.Uri -->
     <Rule Id="CA1054" Action="None" />
     <!-- disable warning CA1055: URI return values should not be strings -->


### PR DESCRIPTION
### Description

This aims to replace the FxCopAnalyzer with the .Net bundled Analyzer

### Changes

* updates analysers to use .NET Analyzers

### Issues

* closes #5 

note:
There are a couple of white space diffs in this, sorry about this! With the introduction/update of the .editorconfig this was to be expected :S

edit:
I had to add a couple of rule ignores to that I am not 100% sure on and would really appreciate a comment on before merging this.